### PR TITLE
Api earthquake filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 __pycache__
 .pytest_cache
+.coverage
 
 terraform.tfvars
 *.tfvars

--- a/api/api.py
+++ b/api/api.py
@@ -10,13 +10,13 @@ from psycopg2.extensions import connection, cursor
 
 app = Flask(__name__)
 
-status_FILTER_KEY = "status_filter"
-network_FILTER_KEY = "network_filter"
-alert_FILTER_KEY = "alert_filter"
-mag_type_FILTER_KEY = "mag_type_filter"
-event_FILTER_KEY = "event_filter"
-min_magnitude_FILTER_KEY = "min_magnitude_filter"
-continent_FILTER_KEY = "continent_filter"
+STATUS_FILTER_KEY = "status_filter"
+NETWORK_FILTER_KEY = "network_filter"
+ALERT_FILTER_KEY = "alert_filter"
+MAG_TYPE_FILTER_KEY = "mag_type_filter"
+EVENT_FILTER_KEY = "event_filter"
+MIN_MAGNITUDE_FILTER_KEY = "min_magnitude_filter"
+CONTINENT_FILTER_KEY = "continent_filter"
 
 
 def get_connection() -> connection:
@@ -39,13 +39,13 @@ def get_filter_queries(earthquake_filters: dict[str]) -> list[str]:
     """Return a list of WHERE command strings that can be added onto a postgreSQL query.
     """
     res = []
-    status = earthquake_filters[status_FILTER_KEY]
-    network = earthquake_filters[network_FILTER_KEY]
-    alert = earthquake_filters[alert_FILTER_KEY]
-    magtype = earthquake_filters[mag_type_FILTER_KEY]
-    event = earthquake_filters[event_FILTER_KEY]
-    min_magnitude = earthquake_filters[min_magnitude_FILTER_KEY]
-    continent = earthquake_filters[continent_FILTER_KEY]
+    status = earthquake_filters[STATUS_FILTER_KEY]
+    network = earthquake_filters[NETWORK_FILTER_KEY]
+    alert = earthquake_filters[ALERT_FILTER_KEY]
+    magtype = earthquake_filters[MAG_TYPE_FILTER_KEY]
+    event = earthquake_filters[EVENT_FILTER_KEY]
+    min_magnitude = earthquake_filters[MIN_MAGNITUDE_FILTER_KEY]
+    continent = earthquake_filters[CONTINENT_FILTER_KEY]
     if status is not None:
         res.append(f"s.status = '{status}'")
     if network is not None:
@@ -59,6 +59,7 @@ def get_filter_queries(earthquake_filters: dict[str]) -> list[str]:
     if min_magnitude is not None:
         res.append(f"e.magnitude >= '{min_magnitude}'")
     if continent is not None:
+        # TODO: implement api to get continent filter working
         res.append("NOT YET IMPLEMENTED")
     res[0] = "WHERE "+res[0]
     return res
@@ -82,7 +83,7 @@ def get_all_earthquakes(earthquake_filters: dict[str]) -> list[dict]:
         search_query += " AND ".join(query_filter_commands)
 
     with get_cursor(conn) as cur:
-        cur.execute(f"{search_query};")
+        cur.execute(search_query)
         fetched_earthquakes = cur.fetchall()
     conn.close()
     return fetched_earthquakes
@@ -99,13 +100,13 @@ def get_earthquakes() -> Response:
     """This endpoint returns a list containing data on every earthquake in our system."""
     try:
         user_filters = {
-            status_FILTER_KEY: request.args.get("status"),
-            network_FILTER_KEY: request.args.get("network"),
-            alert_FILTER_KEY: request.args.get("alert"),
-            mag_type_FILTER_KEY: request.args.get("mag_type"),
-            event_FILTER_KEY: request.args.get("event"),
-            min_magnitude_FILTER_KEY: request.args.get("min_magnitude"),
-            continent_FILTER_KEY: request.args.get("continent")
+            STATUS_FILTER_KEY: request.args.get("status"),
+            NETWORK_FILTER_KEY: request.args.get("network"),
+            ALERT_FILTER_KEY: request.args.get("alert"),
+            MAG_TYPE_FILTER_KEY: request.args.get("mag_type"),
+            EVENT_FILTER_KEY: request.args.get("event"),
+            MIN_MAGNITUDE_FILTER_KEY: request.args.get("min_magnitude"),
+            CONTINENT_FILTER_KEY: request.args.get("continent")
         }
 
         earthquakes = get_all_earthquakes(user_filters)

--- a/api/api.py
+++ b/api/api.py
@@ -47,20 +47,20 @@ def get_filter_queries(earthquake_filters: dict[str]) -> list[str]:
     min_magnitude = earthquake_filters[min_magnitude_FILTER_KEY]
     continent = earthquake_filters[continent_FILTER_KEY]
     if status is not None:
-        res.append(f"WHERE s.status = '{status}'")
+        res.append(f"s.status = '{status}'")
     if network is not None:
-        res.append(f"WHERE n.network_name = '{network}'")
+        res.append(f"n.network_name = '{network}'")
     if alert is not None:
-        res.append(f"WHERE a.alert_value = '{alert}'")
+        res.append(f"a.alert_value = '{alert}'")
     if magtype is not None:
-        res.append(f"WHERE mt.magtype_value = '{magtype}'")
+        res.append(f"mt.magtype_value = '{magtype}'")
     if event is not None:
-        res.append(f"WHERE t.type_value = '{event}'")
+        res.append(f"t.type_value = '{event}'")
     if min_magnitude is not None:
-        res.append(f"WHERE e.magnitude >= '{min_magnitude}'")
+        res.append(f"e.magnitude >= '{min_magnitude}'")
     if continent is not None:
         res.append("NOT YET IMPLEMENTED")
-
+    res[0] = "WHERE "+res[0]
     return res
 
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,4 @@ pylint
 pytest
 flask
 python-dotenv
-psycopg2
+psycopg2-binary

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -110,10 +110,30 @@ def test_get_filter_queries():
 
     assert get_filter_queries(test_filter_dict) == [
         "WHERE s.status = 'status'",
-        "WHERE n.network_name = 'net'",
+        "n.network_name = 'net'",
+        "a.alert_value = 'alert'",
+        "mt.magtype_value = 'magtype'",
+        "t.type_value = 'type'",
+        "e.magnitude >= 'min mag'",
+        "NOT YET IMPLEMENTED"
+    ]
+
+
+def test_get_filter_queries_alert_is_first_filter():
+    test_filter_dict = {
+        status_FILTER_KEY: None,
+        network_FILTER_KEY: None,
+        alert_FILTER_KEY: "alert",
+        mag_type_FILTER_KEY: "magtype",
+        event_FILTER_KEY: "type",
+        min_magnitude_FILTER_KEY: "min mag",
+        continent_FILTER_KEY: "continent"
+    }
+
+    assert get_filter_queries(test_filter_dict) == [
         "WHERE a.alert_value = 'alert'",
-        "WHERE mt.magtype_value = 'magtype'",
-        "WHERE t.type_value = 'type'",
-        "WHERE e.magnitude >= 'min mag'",
+        "mt.magtype_value = 'magtype'",
+        "t.type_value = 'type'",
+        "e.magnitude >= 'min mag'",
         "NOT YET IMPLEMENTED"
     ]

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -1,7 +1,8 @@
 # pylint: skip-file
 from dotenv import load_dotenv
 import pytest
-from api import app
+from api import app, status_FILTER_KEY, network_FILTER_KEY, alert_FILTER_KEY, mag_type_FILTER_KEY, event_FILTER_KEY, min_magnitude_FILTER_KEY, continent_FILTER_KEY, get_filter_queries
+
 from unittest.mock import patch
 
 load_dotenv()
@@ -12,6 +13,74 @@ def client():
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
+
+
+@pytest.fixture()
+def example_api_response():
+    return [
+        {
+            "alert": None,
+            "cause_of_event": "earthquake",
+            "cdi": None,
+            "depth": 1.96,
+            "dmin": 0.006074,
+            "earthquake_id": "nc75025077",
+            "felt": None,
+            "gap": 165.0,
+            "lat": "38.833332",
+            "lon": "-122.878830",
+            "magnitude": 0.78,
+            "magtype": "md",
+            "mmi": None,
+            "network_name": "nc",
+            "nst": 16,
+            "significance": 9,
+            "status": "automatic",
+            "time": "Fri, 21 Jun 2024 20:18:40 GMT",
+            "title": "M 0.8 - 12 km NW of The Geysers, CA"
+        },
+        {
+            "alert": None,
+            "cause_of_event": "earthquake",
+            "cdi": None,
+            "depth": 10.88,
+            "dmin": 0.05398,
+            "earthquake_id": "ci40806056",
+            "felt": None,
+            "gap": 63.0,
+            "lat": "33.494499",
+            "lon": "-116.480331",
+            "magnitude": 1.04,
+            "magtype": "ml",
+            "mmi": None,
+            "network_name": "ci",
+            "nst": 26,
+            "significance": 17,
+            "status": "reviewed",
+            "time": "Fri, 21 Jun 2024 20:16:06 GMT",
+            "title": "M 1.0 - 19 km ESE of Anza, CA"
+        },
+        {
+            "alert": None,
+            "cause_of_event": "earthquake",
+            "cdi": None,
+            "depth": 2.02,
+            "dmin": 0.008128,
+            "earthquake_id": "nc75025072",
+            "felt": None,
+            "gap": 174.0,
+            "lat": "38.821999",
+            "lon": "-122.845337",
+            "magnitude": 0.24,
+            "magtype": "md",
+            "mmi": None,
+            "network_name": "nc",
+            "nst": 8,
+            "significance": 1,
+            "status": "deleted",
+            "time": "Fri, 21 Jun 2024 20:10:08 GMT",
+            "title": "M 0.2 - 9 km NW of The Geysers, CA"
+        }]
 
 
 def test_endpoint_index(client):
@@ -26,3 +95,25 @@ def test_endpoint_get_earthquakes(mock_all_earthquakes, client):
     response = client.get("/earthquakes")
     assert response.status_code == 200
     assert isinstance(response.json, list)
+
+
+def test_get_filter_queries():
+    test_filter_dict = {
+        status_FILTER_KEY: "status",
+        network_FILTER_KEY: "net",
+        alert_FILTER_KEY: "alert",
+        mag_type_FILTER_KEY: "magtype",
+        event_FILTER_KEY: "type",
+        min_magnitude_FILTER_KEY: "min mag",
+        continent_FILTER_KEY: "continent"
+    }
+
+    assert get_filter_queries(test_filter_dict) == [
+        "WHERE s.status = 'status'",
+        "WHERE n.network_name = 'net'",
+        "WHERE a.alert_value = 'alert'",
+        "WHERE mt.magtype_value = 'magtype'",
+        "WHERE t.type_value = 'type'",
+        "WHERE e.magnitude >= 'min mag'",
+        "NOT YET IMPLEMENTED"
+    ]

--- a/api/test_api.py
+++ b/api/test_api.py
@@ -1,7 +1,7 @@
 # pylint: skip-file
 from dotenv import load_dotenv
 import pytest
-from api import app, status_FILTER_KEY, network_FILTER_KEY, alert_FILTER_KEY, mag_type_FILTER_KEY, event_FILTER_KEY, min_magnitude_FILTER_KEY, continent_FILTER_KEY, get_filter_queries
+from api import app, STATUS_FILTER_KEY, NETWORK_FILTER_KEY, ALERT_FILTER_KEY, MAG_TYPE_FILTER_KEY, EVENT_FILTER_KEY, MIN_MAGNITUDE_FILTER_KEY, CONTINENT_FILTER_KEY, get_filter_queries
 
 from unittest.mock import patch
 
@@ -99,13 +99,13 @@ def test_endpoint_get_earthquakes(mock_all_earthquakes, client):
 
 def test_get_filter_queries():
     test_filter_dict = {
-        status_FILTER_KEY: "status",
-        network_FILTER_KEY: "net",
-        alert_FILTER_KEY: "alert",
-        mag_type_FILTER_KEY: "magtype",
-        event_FILTER_KEY: "type",
-        min_magnitude_FILTER_KEY: "min mag",
-        continent_FILTER_KEY: "continent"
+        STATUS_FILTER_KEY: "status",
+        NETWORK_FILTER_KEY: "net",
+        ALERT_FILTER_KEY: "alert",
+        MAG_TYPE_FILTER_KEY: "magtype",
+        EVENT_FILTER_KEY: "type",
+        MIN_MAGNITUDE_FILTER_KEY: "min mag",
+        CONTINENT_FILTER_KEY: "continent"
     }
 
     assert get_filter_queries(test_filter_dict) == [
@@ -121,13 +121,13 @@ def test_get_filter_queries():
 
 def test_get_filter_queries_alert_is_first_filter():
     test_filter_dict = {
-        status_FILTER_KEY: None,
-        network_FILTER_KEY: None,
-        alert_FILTER_KEY: "alert",
-        mag_type_FILTER_KEY: "magtype",
-        event_FILTER_KEY: "type",
-        min_magnitude_FILTER_KEY: "min mag",
-        continent_FILTER_KEY: "continent"
+        STATUS_FILTER_KEY: None,
+        NETWORK_FILTER_KEY: None,
+        ALERT_FILTER_KEY: "alert",
+        MAG_TYPE_FILTER_KEY: "magtype",
+        EVENT_FILTER_KEY: "type",
+        MIN_MAGNITUDE_FILTER_KEY: "min mag",
+        CONTINENT_FILTER_KEY: "continent"
     }
 
     assert get_filter_queries(test_filter_dict) == [


### PR DESCRIPTION
This merge should add functionality to the api so that multiple options are available for the earthquakes endpoint, allowing users to filter through the RDS data e.g. earthquakes with a minimum magnitude of 3, events that are labelled 'quarry blasts' etc.